### PR TITLE
Add a cookiecutter based sample template

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Prettier changes double curly braces and makes files like catalog-info.yaml invalid
+scaffolder-templates

--- a/scaffolder-templates/docs-template-cookiecutter/skeleton/catalog-info.yaml
+++ b/scaffolder-templates/docs-template-cookiecutter/skeleton/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: {{cookiecutter.name | jsonify}}
+  description: {{cookiecutter.description | jsonify}}
+  annotations:
+    github.com/project-slug: {{cookiecutter.destination.owner + "/" + cookiecutter.destination.repo}}
+    backstage.io/techdocs-ref: url:{{"https://" + cookiecutter.destination.host + "/" + cookiecutter.destination.owner + "/" + cookiecutter.destination.repo}}
+spec:
+  type: documentation
+  lifecycle: experimental
+  owner: {{cookiecutter.owner | jsonify}}

--- a/scaffolder-templates/docs-template-cookiecutter/skeleton/catalog-info.yaml
+++ b/scaffolder-templates/docs-template-cookiecutter/skeleton/catalog-info.yaml
@@ -5,7 +5,7 @@ metadata:
   description: {{cookiecutter.description | jsonify}}
   annotations:
     github.com/project-slug: {{cookiecutter.destination.owner + "/" + cookiecutter.destination.repo}}
-    backstage.io/techdocs-ref: url:{{"https://" + cookiecutter.destination.host + "/" + cookiecutter.destination.owner + "/" + cookiecutter.destination.repo}}
+    backstage.io/techdocs-ref: dir:.
 spec:
   type: documentation
   lifecycle: experimental

--- a/scaffolder-templates/docs-template-cookiecutter/skeleton/docs/index.md
+++ b/scaffolder-templates/docs-template-cookiecutter/skeleton/docs/index.md
@@ -1,0 +1,28 @@
+## {{ cookiecutter.name }}
+
+{{ cookiecutter.description }}
+
+## Getting started
+
+Start write your documentation by adding more markdown (.md) files to this folder (/docs) or replace the content in this file.
+
+## Table of Contents
+
+The Table of Contents on the right is generated automatically based on the hierarchy
+of headings. Only use one H1 (`#` in Markdown) per file.
+
+## Site navigation
+
+For new pages to appear in the left hand navigation you need edit the `mkdocs.yml`
+file in root of your repo. The navigation can also link out to other sites.
+
+Alternatively, if there is no `nav` section in `mkdocs.yml`, a navigation section
+will be created for you. However, you will not be able to use alternate titles for
+pages, or include links to other sites.
+
+Note that MkDocs uses `mkdocs.yml`, not `mkdocs.yaml`, although both appear to work.
+See also <https://www.mkdocs.org/user-guide/configuration/>.
+
+## Support
+
+That's it. If you need support, reach out in [#docs-like-code](https://discord.com/channels/687207715902193673/714754240933003266) on Discord.

--- a/scaffolder-templates/docs-template-cookiecutter/skeleton/mkdocs.yml
+++ b/scaffolder-templates/docs-template-cookiecutter/skeleton/mkdocs.yml
@@ -1,0 +1,8 @@
+site_name: {{cookiecutter.name | jsonify}}
+site_description: {{cookiecutter.description | jsonify}}
+
+nav:
+  - Introduction: index.md
+
+plugins:
+  - techdocs-core

--- a/scaffolder-templates/docs-template-cookiecutter/template.yaml
+++ b/scaffolder-templates/docs-template-cookiecutter/template.yaml
@@ -1,13 +1,13 @@
 apiVersion: backstage.io/v1beta2
 kind: Template
 metadata:
-  name: docs-template
-  title: Documentation Template
-  description: Create a new standalone documentation project
+  name: docs-template-cookiecutter
+  title: Documentation Template (Cookiecutter)
+  description: Create a new standalone documentation project using Cookiecutter
   tags:
-    - recommended
     - techdocs
     - mkdocs
+    - cookiecutter
 spec:
   owner: backstage/techdocs-core
   type: documentation
@@ -51,13 +51,13 @@ spec:
             allowedHosts:
               - github.com
 
-  # This template is meant to be used on top of an existing template.
+  # This template can be used on top of an existing software template to add docs.
   # By adding the following and fetching from an absolute URL you can
   # add in the docs template
   steps:
     - id: fetch
       name: Template Docs Skeleton
-      action: fetch:template
+      action: fetch:cookiecutter
       input:
         url: ./skeleton
         values:


### PR DESCRIPTION
Since we are going to continue the support for fetch:cookiecutter action and since the cookicutter based sample templates in backstage/backstage are being removed under backstage/backstage#6415, it makes sense to have a cookiecutter based sample template in this repository.

We are not going to include this template in the default [backstage example-app config](https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend/sample-templates/remote-templates.yaml) to avoid confusion for new integrators.