### PR TITLE
fix: replace parameters.component_id with name

### DIFF
--- a/scaffolder-templates/docs-template-cookiecutter/template.yaml
+++ b/scaffolder-templates/docs-template-cookiecutter/template.yaml
@@ -71,7 +71,7 @@ spec:
       action: publish:github
       input:
         allowedHosts: ["github.com"]
-        description: "This is {{ parameters.component_id }}"
+        description: "This is {{ parameters.name }}"
         repoUrl: "{{ parameters.repoUrl }}"
 
     - id: register

--- a/scaffolder-templates/docs-template/template.yaml
+++ b/scaffolder-templates/docs-template/template.yaml
@@ -68,7 +68,7 @@ spec:
       action: publish:github
       input:
         allowedHosts: ["github.com"]
-        description: This is ${{ parameters.component_id }}
+        description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.repoUrl }}
 
     - id: register


### PR DESCRIPTION
Replace `parameters.component_id` with `parameters.name`
which is the actual parameter name as defined at
`spec.parameters`.

Remark:

At other templates, `component_id` is used for the same field.
At the documentation on backstage.io it is called name.