### PR TITLE
chore: fixing broken catalog:write action

### DIFF
--- a/scaffolder-templates/rails-demo/template.yaml
+++ b/scaffolder-templates/rails-demo/template.yaml
@@ -129,7 +129,7 @@ spec:
     - name: Write Catalog information
       action: catalog:write
       input:
-        component:
+        entity:
           apiVersion: 'backstage.io/v1alpha1'
           kind: Component
           metadata:
@@ -140,6 +140,7 @@ spec:
             type: service
             lifecycle: production
             owner: ${{ parameters.owner }}
+        filePath: 'catalog-info.yaml'
 
     - id: publish
       if: ${{ parameters.dryRun !== true }}


### PR DESCRIPTION
The "component" object threw errors whils Scaffolding.

I went to the `{Domain}/create/actions` page and following the reference, switched it to entity object and got it to work.