### PR TITLE
Update to use title and correct the output

### DIFF
--- a/scaffolder-templates/pull-request/template.yaml
+++ b/scaffolder-templates/pull-request/template.yaml
@@ -71,4 +71,4 @@ spec:
   output:
     links:
       - url: ${{steps.publish.output.remoteUrl}}
-        text: "Go to PR"
+        title: "Go to PR"


### PR DESCRIPTION
This template incorrectly uses text instead of title for the output, so this very small PR updates this to the correct value.

I've check all other templates and they are all correct.