### PR TITLE
Add software-templates to Backstage Software Catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: software-templates
+  annotations:
+    github.com/project-slug: 'backstage/software-templates'
+spec:
+  type: website
+  lifecycle: production
+  owner: infinite-bucks


### PR DESCRIPTION

## TL;DR

This pull request registers software-templates, as a component in our Backstage Software Catalog.
It lists our team, infinite-bucks, as the owners of this component.
After this file has merged, you can view this component in Backstage Software Catalog here: → https://pr-1726-deployment-55090-backstage-portal.app.uffizzi.com/catalog

## What is Portal?

[Portal](https://backstage.spotify.com/products/portal) is an internal developer portal based on [Backstage](https://backstage.io/). It's goal is making developers' lives easier. Portal unifies all your infrastructure tooling, services, and documentation to create a streamlined development environment from end to end.
