### PR TITLE
Fix Invalid input passed to action `publish:github`

### DIFF
--- a/scaffolder-templates/create-react-app/template.yaml
+++ b/scaffolder-templates/create-react-app/template.yaml
@@ -62,8 +62,6 @@ spec:
       name: Publish
       action: publish:github
       input:
-        allowedHosts:
-          - github.com
         description: This is ${{ parameters.component_id }}
         repoUrl: ${{ parameters.repoUrl }}
 


### PR DESCRIPTION
Ref: https://github.com/backstage/community-plugins/pull/5356

Fix for `InputError: Invalid input passed to action publish:github, instance is not allowed to have the additional property "allowedHosts"`