### PR TITLE
Remove invalid allowed hosts input

### DIFF
--- a/scaffolder-templates/clean-architecture-app/template.yaml
+++ b/scaffolder-templates/clean-architecture-app/template.yaml
@@ -111,7 +111,6 @@ spec:
       name: Publish
       action: publish:github
       input:
-        allowedHosts: ['github.com','dev.azure.com']
         description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.repoUrl }}
 

--- a/scaffolder-templates/docs-template-cookiecutter/template.yaml
+++ b/scaffolder-templates/docs-template-cookiecutter/template.yaml
@@ -70,8 +70,6 @@ spec:
       name: Publish
       action: publish:github
       input:
-        allowedHosts:
-          - github.com
         description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.repoUrl }}
 

--- a/scaffolder-templates/docs-template/template.yaml
+++ b/scaffolder-templates/docs-template/template.yaml
@@ -67,7 +67,6 @@ spec:
       name: Publish
       action: publish:github
       input:
-        allowedHosts: ["github.com"]
         description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.repoUrl }}
 

--- a/scaffolder-templates/rails-demo/template.yaml
+++ b/scaffolder-templates/rails-demo/template.yaml
@@ -147,8 +147,6 @@ spec:
       name: Publish
       action: publish:github
       input:
-        allowedHosts:
-          - github.com
         description: This is ${{ parameters.name }}
         repoUrl: ${{ parameters.repoUrl }}
 

--- a/scaffolder-templates/react-ssr-template/template.yaml
+++ b/scaffolder-templates/react-ssr-template/template.yaml
@@ -62,7 +62,6 @@ spec:
       name: Publish
       action: publish:github
       input:
-        allowedHosts: ["github.com"]
         description: This is ${{ parameters.component_id }}
         repoUrl: ${{ parameters.repoUrl }}
 

--- a/scaffolder-templates/springboot-grpc-template/template.yaml
+++ b/scaffolder-templates/springboot-grpc-template/template.yaml
@@ -73,7 +73,6 @@ spec:
       name: Publish
       action: publish:github
       input:
-        allowedHosts: ["github.com"]
         description: This is ${{ parameters.component_id }}
         repoUrl: ${{ parameters.repoUrl }}
 


### PR DESCRIPTION
Ref: https://github.com/backstage/community-plugins/pull/5356
Follow-up of: https://github.com/backstage/software-templates/pull/57

Fix for `InputError: Invalid input passed to action publish:github, instance is not allowed to have the additional property "allowedHosts"`.